### PR TITLE
Add a direct link to trace URLs

### DIFF
--- a/app/assets/components/TraceInfo.coffee
+++ b/app/assets/components/TraceInfo.coffee
@@ -28,13 +28,12 @@ export class Field extends Component
   render: ->
     { title, value, href } = this.props
 
-    if value?
-      value = value.toString()
-
     $ 'div',
       $ 'h4', title
       do =>
-        if value
-          $ 'a', title: value, href: href, value
+        if value? && href
+          $ 'a', title: value.toString(), href: href, value.toString()
+        else if value?
+          $ 'p', value
         else
           $ 'a', className: 'empty', '<none>'

--- a/app/assets/components/TraceMeta.coffee
+++ b/app/assets/components/TraceMeta.coffee
@@ -3,6 +3,8 @@ import {
   createElement as $
 } from './core'
 
+import FaExternalLink from 'preact-icons/fa/external-link'
+
 import URIJS from 'urijs'
 
 import { Field } from './TraceInfo'
@@ -45,8 +47,7 @@ class WebMeta extends Component
         href: routes.traces_url(ws: meta['status']) if meta['status']?
       $ Field,
         title: 'Path'
-        value: meta['path']
-        href: routes.traces_url(application: application['uuid'], wp: meta['path']) if meta['path']?
+        value: this.pathField()
       $ Field,
         title: 'Query'
         value: meta['query']
@@ -54,6 +55,25 @@ class WebMeta extends Component
         title: 'Action'
         value: meta['action']
         href: routes.traces_url(application: application['uuid'], wc: meta['controller'], wa: meta['action']) if meta['action']?
+
+  pathField: ->
+    { routes } = this.context
+    { application, meta } = this.props.trace
+
+    return unless meta['path']?
+
+    traceUrl = routes.traces_url(application: application['uuid'], wp: meta['path'])
+
+    # If it makes sense, let's add a direct link to the request's URL
+    if meta['method'] == 'GET' && meta['host']?
+      visitUrl = 'http://' + meta['host'] + meta['path']
+
+      [
+        $('a', href: traceUrl, meta['path']),
+        $('a', href: visitUrl, class: 'external', $(FaExternalLink))
+      ]
+    else
+      $ 'a', href: traceUrl, meta['path']
 
 
 class JobMeta extends Component

--- a/app/assets/components/TraceView.sass
+++ b/app/assets/components/TraceView.sass
@@ -165,30 +165,31 @@
       &:nth-child(5n), &:first-child
         border-left-width: 1px
 
-      > h4, > a
+      > h4, > a, > p
         line-height: 1.4rem
         font-size: 0.7rem
+        margin: 0
+        padding: 2px 0.4rem
 
       > h4
         text-align: right
-        margin: 0
         min-width: 80px
-        padding: 2px 0.4rem
-
         color: #555
         background: #f6f6f6
 
-      > a
+      > a, > p
         background: #fff
         width: 100%
-        margin: 0
-        padding: 2px 0.4rem
         text-overflow: ellipsis
         overflow: hidden
         white-space: nowrap
 
-        &.empty
-          color: #999
+      > a.empty
+        color: #999
+
+      a.external
+        padding-left: 5px
+        padding-right: 5px
 
       @media (max-width: 1024px)
         flex-direction: column


### PR DESCRIPTION
- Only for GET requests
- Only when domain and path were given

Fixes #11.