### PR TITLE
Don't sample out traces with errors

### DIFF
--- a/app/views/traces/trace_not_found.html.slim
+++ b/app/views/traces/trace_not_found.html.slim
@@ -1,4 +1,4 @@
 .notice
   h3 Could not find trace
-  p If you copied a trace ID from HTTP request headers or an error page, it might not yet have been processed - Mnemosyne can be busy sometimes. Also, please note that traces are not stored forever. If you came here with an older trace ID, the data may have already been deleted again.
+  p If you copied a trace ID from HTTP request headers or an error page, it might not yet have been processed - Mnemosyne can be busy sometimes. Also, please note that not all traces without errors are stored. Furthermore, stored traces are deleted after a retention period. If you came here with an older trace ID, the data may have already been deleted again.
   p If you are certain that this trace should exist, please try again at a later date.

--- a/spec/lib/server/pipeline/filter/sample_spec.rb
+++ b/spec/lib/server/pipeline/filter/sample_spec.rb
@@ -29,6 +29,22 @@ RSpec.describe ::Server::Pipeline::Filter::Sample do
         transaction: 'cca7e687-58d8-4fc9-a47b-5c623897076d'
       })).to yield_control
     end
+
+    it 'does not filter traces with errors even if they match' do
+      expect(mk_call({
+        transaction: '035c9059-238b-4f9e-9505-bc73f2ee39ed',
+        errors: [{
+          type: 'RuntimeError',
+          text: 'error message',
+          stacktrace: [{
+            file: '(pry)',
+            line: '2',
+            call: 'm',
+            raw: "(pry):2:in `m'",
+          }],
+        }],
+      })).to yield_control
+    end
   end
 
   describe 'platform filter' do
@@ -41,6 +57,26 @@ RSpec.describe ::Server::Pipeline::Filter::Sample do
 
     it 'does not filter traces of non-matching platforms' do
       expect(mk_call({platform: 'other'})).to yield_control
+    end
+  end
+
+  describe 'keep_errors option' do
+    let(:filter) { described_class.new(rate: 0.5, keep_errors: false) }
+
+    it 'does again filter matching traces with errors' do
+      expect(mk_call({
+        transaction: '035c9059-238b-4f9e-9505-bc73f2ee39ed',
+        errors: [{
+          type: 'RuntimeError',
+          text: 'error message',
+          stacktrace: [{
+            file: '(pry)',
+            line: '2',
+            call: 'm',
+            raw: "(pry):2:in `m'",
+          }],
+        }],
+      })).to_not yield_control
     end
   end
 end


### PR DESCRIPTION
Mostly, error traces are the only ones I am interested in. That's
where Mnemosyne is most useful to me. So even though I understand
the necessity of sampling, I'd prefer if failures were kept.

We talked about this in person a while ago, so I hope this is fine.