### PR TITLE
Calculate trace spans only once

### DIFF
--- a/app/decorators/trace_decorator.rb
+++ b/app/decorators/trace_decorator.rb
@@ -34,10 +34,8 @@ class TraceDecorator < BaseDecorator
   end
 
   def stats
-    pp spans.map(&:stats).reduce(&:+)
-
     {
-      count: spans.map(&:stats).sum.as_json
+      count: spans.sum(&:stats).as_json
     }
   end
 


### PR DESCRIPTION
Seems like a debug statement was forgotten in the code. Also, passing a block to `sum` means we only iterate once.