### PR TITLE
Fix TypeError when `l['file']` is empty

### DIFF
--- a/app/views/failures/_stacktrace.html.slim
+++ b/app/views/failures/_stacktrace.html.slim
@@ -3,7 +3,7 @@ table.stacktrace
     tr
       td.file
         span= l['file'].split('/')[0..-2].join('/')
-        span= '/' + l['file'].split('/')[-1]
+        span= '/' + l['file'].split('/')[-1].to_s
       td.line= l['line']
       td.call= l['call']
 


### PR DESCRIPTION
Otherwise, a `TypeError: no implicit conversion of nil into String` could occur for the `+` operator.

- [Failure Trace](https://dev.xikolo.de/mnemosyne/platform/codeocean/traces/62cb8ceb-faa4-4949-a11e-4eb2d19bdd09#sm-7a0d127f-770d-4c36-b283-5293873755d4)
- [Exception Details](https://dev.xikolo.de/mnemosyne/platform/mnemosyne/failures/fdcd02f4-c5a8-4b1b-989b-57d8011dee67)

Caused by the error shown on [this failure trace](https://dev.xikolo.de/mnemosyne/platform/codeocean/traces/62cb8ceb-faa4-4949-a11e-4eb2d19bdd09). As I don't know the data model, the fix might not be sufficient, so feel free to test it first 🙂