### PR TITLE
fix: Syntax error in custom interval SQL clause since 7.2 upgrade

### DIFF
--- a/app/controllers/traces_controller.rb
+++ b/app/controllers/traces_controller.rb
@@ -70,11 +70,11 @@ class TracesController < ApplicationController
   end
 
   has_scope :ls do |_, scope, value|
-    scope.where("(stop - start) >= interval ?", ::ActiveSupport::Duration.parse_string(value).iso8601)
+    scope.latency_above(value)
   end
 
   has_scope :le do |_, scope, value|
-    scope.where("(stop - start) < interval ?", ::ActiveSupport::Duration.parse_string(value).iso8601)
+    scope.latency_below(value)
   end
 
   has_scope :meta, type: :hash do |_, scope, value|

--- a/app/models/trace.rb
+++ b/app/models/trace.rb
@@ -31,6 +31,16 @@ class Trace < ApplicationRecord
       where t[:stop].lt(tlimit).and(t[:store].eq(false))
     end
 
+    def latency_above(value)
+      duration = ::ActiveSupport::Duration.parse_string(value)
+      where("(stop - start) >= ?", duration.iso8601)
+    end
+
+    def latency_below(value)
+      duration = ::ActiveSupport::Duration.parse_string(value)
+      where("(stop - start) < ?", duration.iso8601)
+    end
+
     alias t arel_table
   end
 end

--- a/spec/models/trace_spec.rb
+++ b/spec/models/trace_spec.rb
@@ -104,5 +104,47 @@ RSpec.describe Trace do
         end
       end
     end
+
+    describe ".latency_above" do
+      subject(:traces) { described_class.latency_above(value) }
+
+      let(:value) { "5s" }
+
+      let!(:expected) do
+        create(:trace, :w_spans, start: Time.zone.now, stop: Time.zone.now + 10)
+      end
+
+      before do
+        create(:trace, :w_spans, start: Time.zone.now, stop: Time.zone.now + 4)
+        create(:trace, :w_spans, start: Time.zone.now, stop: Time.zone.now + 2)
+      end
+
+      it "returns only traces above 5 seconds in length" do
+        expect(described_class.count).to eq 3
+
+        expect(traces).to contain_exactly(expected)
+      end
+    end
+
+    describe ".latency_below" do
+      subject(:traces) { described_class.latency_below(value) }
+
+      let(:value) { "5s" }
+
+      let!(:expected) do
+        create(:trace, :w_spans, start: Time.zone.now, stop: Time.zone.now + 4)
+      end
+
+      before do
+        create(:trace, :w_spans, start: Time.zone.now, stop: Time.zone.now + 6)
+        create(:trace, :w_spans, start: Time.zone.now, stop: Time.zone.now + 10)
+      end
+
+      it "returns only traces above 5 seconds in length" do
+        expect(described_class.count).to eq 3
+
+        expect(traces).to contain_exactly(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
Intervals in the latency filter scopes must not be coded as `interval ?` anymore, but only `?`, despite being passed as strings only. Otherwise, the following error is raised:

    ActiveRecord::StatementInvalid:
      PG::SyntaxError: ERROR:  syntax error at or near "$1"
      LINE 1: ...traces".* FROM "traces" WHERE ((stop - start) < interval $1)
                                                                          ^

This commit further extracts the two latency param filters into model scopes, and adds specs for both. Since we have no request/system specs here yet, testing the scopes on the models is easier, and will continue to ensure that these scopes do work.